### PR TITLE
Fix client types resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,13 @@
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {
-    "require": "./dist/index.js",
-    "import": "./dist/index.mjs"
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    },
+    "./client": {
+      "types": "./client.d.ts"
+    }
   },
   "types": "./dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
For a long time I didn't understand why I had to modify `typeRoots` in my tsconfig to make this package work:

```
    "typeRoots": [
      "./node_modules/@types",
      "./node_modules" <- this is needed, otherwise it won't work
    ],
    "types": [
      "vite/client",
      "vite-plugin-compile-time/client"
    ]
```

So I finally looked at how vite itself does it, and the missing piece is right here: https://github.com/vitejs/vite/blob/55461b43329db6a5e737eab591163a8681ba9230/packages/vite/package.json#L32-L34

I confirmed this change works locally. Modifying `typeRoots` is no longer required. Which is good because it slows down tsc.